### PR TITLE
Resolved bug where editing two or more staff member data would result…

### DIFF
--- a/static/manStaff.js
+++ b/static/manStaff.js
@@ -119,7 +119,7 @@ function addRow(data, table) {
 
         if (d == "startDate") {
             let tmp = new Date(data[i]);
-            col.innerHTML = tmp.getFullYear().toString()+"-"+(tmp.getMonth()+1).toString()+"-"+tmp.getDate().toString();
+            col.innerHTML = tmp.toISOString().substring(0,10);
 
         } else if (d == "color") {
             let tmp = document.createElement("input");


### PR DESCRIPTION
… in 0 year error. This was caused by the addRow function showing startDates as YYYY-m-DD instead of YYYY-MM-DD format