### PR TITLE
P2 Training Bug: Calendar not displaying new schedule

### DIFF
--- a/conflicts/conflicts.py
+++ b/conflicts/conflicts.py
@@ -500,14 +500,14 @@ def processConflicts():
 
         # Execute a DELETE statement to remove the previously entered conflicts
         #  that are no longer needed.
-        cur.execute("""DELETE FROM conflicts
-                       WHERE conflicts.day_id IN (
-                            SELECT conflicts.day_id
-                            FROM conflicts
-                                JOIN day ON (conflicts.day_id = day.id)
-                            WHERE TO_CHAR(day.date, 'YYYY-MM-DD') IN %s
-                            AND conflicts.ra_id = %s
-                        );""", (tuple(deleteSet), authedUser.ra_id()))
+        cur.execute("""
+            DELETE FROM conflicts
+            WHERE conflicts.day_id IN (
+                SELECT conflicts.day_id
+                FROM conflicts JOIN day ON (conflicts.day_id = day.id)
+                WHERE TO_CHAR(day.date, 'YYYY-MM-DD') IN %s
+                AND conflicts.ra_id = %s
+            );""", (tuple(deleteSet), authedUser.ra_id()))
 
         # Set the flag to indicate that we have made changes to the DB
         madeChanges = True

--- a/conflicts/tests/conflictBP_processConflicts_test.py
+++ b/conflicts/tests/conflictBP_processConflicts_test.py
@@ -393,15 +393,14 @@ class TestConflictBP_getRAConflicts(unittest.TestCase):
         # Assert that the when the appGlobals.conn.cursor().execute was called,
         #  one of the calls was the following. Since this line is using triple-
         #  quote strings, the whitespace must match exactly.
-        self.mocked_appGlobals.conn.cursor().execute.assert_any_call(
-            """DELETE FROM conflicts
-                       WHERE conflicts.day_id IN (
-                            SELECT conflicts.day_id
-                            FROM conflicts
-                                JOIN day ON (conflicts.day_id = day.id)
-                            WHERE TO_CHAR(day.date, 'YYYY-MM-DD') IN %s
-                            AND conflicts.ra_id = %s
-                        );""", (tuple(deleteSet), self.user_ra_id)
+        self.mocked_appGlobals.conn.cursor().execute.assert_any_call("""
+            DELETE FROM conflicts
+            WHERE conflicts.day_id IN (
+                SELECT conflicts.day_id
+                FROM conflicts JOIN day ON (conflicts.day_id = day.id)
+                WHERE TO_CHAR(day.date, 'YYYY-MM-DD') IN %s
+                AND conflicts.ra_id = %s
+            );""", (tuple(deleteSet), self.user_ra_id)
         )
 
         # Assert that the when the appGlobals.conn.cursor().execute was called,

--- a/conflicts/tests/conflictBP_processConflicts_test.py
+++ b/conflicts/tests/conflictBP_processConflicts_test.py
@@ -317,15 +317,14 @@ class TestConflictBP_getRAConflicts(unittest.TestCase):
         # Assert that the when the appGlobals.conn.cursor().execute was last called,
         #  it was an Delete statement. Since this line is using triple-quote strings,
         #  the whitespace must match exactly.
-        self.mocked_appGlobals.conn.cursor().execute.assert_called_with(
-            """DELETE FROM conflicts
-                       WHERE conflicts.day_id IN (
-                            SELECT conflicts.day_id
-                            FROM conflicts
-                                JOIN day ON (conflicts.day_id = day.id)
-                            WHERE TO_CHAR(day.date, 'YYYY-MM-DD') IN %s
-                            AND conflicts.ra_id = %s
-                        );""", (tuple(set(desiredNewConflicts[15:])), self.user_ra_id))
+        self.mocked_appGlobals.conn.cursor().execute.assert_called_with("""
+            DELETE FROM conflicts
+            WHERE conflicts.day_id IN (
+                SELECT conflicts.day_id
+                FROM conflicts JOIN day ON (conflicts.day_id = day.id)
+                WHERE TO_CHAR(day.date, 'YYYY-MM-DD') IN %s
+                AND conflicts.ra_id = %s
+            );""", (tuple(set(desiredNewConflicts[15:])), self.user_ra_id))
 
         # Assert that appGlobals.conn.commit was never called
         self.mocked_appGlobals.conn.commit.assert_called_once()

--- a/schedule/schedule.py
+++ b/schedule/schedule.py
@@ -1054,7 +1054,7 @@ def addNewDuty():
                      .format(monthId, authedUser.hall_id()))
 
         # Insert the schedule entry into the DB
-        cur.execute("INSERT INTO schedule (hall_id, month_id) VALUES (%s, %s) RETURNING id",
+        cur.execute("INSERT INTO schedule (hall_id, month_id, created) VALUES (%s, %s, NOW()) RETURNING id",
                     (authedUser.hall_id(), monthId))
 
         # Load the schedule ID from the DB

--- a/schedule/tests/schedule_addNewDuty_test.py
+++ b/schedule/tests/schedule_addNewDuty_test.py
@@ -283,7 +283,7 @@ class TestSchedule_addNewDuty(unittest.TestCase):
         # Assert that appGlobals.conn.cursor().close was called
         self.mocked_appGlobals.conn.cursor().close.assert_called_once()
 
-    def test_withAuthorizedUser_withoutValidSchedule_returnsInvalidScheduleResponse(self):
+    def test_withAuthorizedUser_withoutValidSchedule_returnsCreatesNewScheduleEntry(self):
         # Test to ensure that when an authorized user attempts to use this API,
         #  if no schedule is available, this will create a new schedule record.
 
@@ -331,7 +331,7 @@ class TestSchedule_addNewDuty(unittest.TestCase):
         # Assert that one of the times appGlobals.conn.cursor().execute was called,
         #  it was a query to insert a new schedule record.
         self.mocked_appGlobals.conn.cursor().execute.assert_any_call(
-            "INSERT INTO schedule (hall_id, month_id) VALUES (%s, %s) RETURNING id",
+            "INSERT INTO schedule (hall_id, month_id, created) VALUES (%s, %s, NOW()) RETURNING id",
             (self.user_hall_id, expectedMonthID)
         )
 


### PR DESCRIPTION
Addressed bug where, when addNewDuty() attempted to create a new schedule, it would leave the created field NULL which resulted in getDutySchedule2() to miscalculate what the latest schedule should be.